### PR TITLE
Patch 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ exports.handler = function(event, context) {
         dest.unshift(DEST_DIR);
         
         // Store the image and the correct location
-        return putObject({Bucket: bucket, Key: dest.join('/'), Body: buffer, ContentType: contentType});
+        return putObject({Bucket: bucket, Key: dest.join('/'), Body: buffer, ContentType: contentType, ACL:'public-read'});
     }).then(function() {
         // Everything went well
         context.succeed();

--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ exports.handler = function(event, context) {
     }).spread(function(contentType, buffer) {
         // Determine the destination of the thumbnail
         var dest = source.split('/');
-        dest.shift();
         dest.unshift(DEST_DIR);
         
         // Store the image and the correct location


### PR DESCRIPTION
FIX: don't shift the key so the object keys isn't lost and image isn't sent to same "thumbs" file
FEATURE: default to world readable so thumbnail can be immediately read
